### PR TITLE
Use print function

### DIFF
--- a/modularodm/storedobject.py
+++ b/modularodm/storedobject.py
@@ -587,22 +587,20 @@ class StoredObject(object):
         if verbose:
             deleted_fields = [field for field in old._fields if field not in new._fields]
             added_fields = [field for field in new._fields if field not in old._fields]
-            print 'Will delete fields:', deleted_fields
-            print 'Will add fields:', added_fields
+            print('Will delete fields: {0}'.format(deleted_fields))
+            print('Will add fields: {0}'.format(added_fields))
 
         # Check change in primary key
         if verbose and old._primary_name != new._primary_name:
-            print '''
-                The primary key will change from {old_name}: {old_field} to
-                {new_name}: {new_field} in this migration. Primary keys and backreferences
-                will not be automatically migrated. If you want to migrate primary keys,
-                you should handle this in your migrate() method.
-            '''.format(
-                old_name=old._primary_name,
-                old_field=old._fields[old._primary_name],
-                new_name=new._primary_name,
-                new_field=new._fields[new._primary_name],
-            )
+            print("The primary key will change from {old_name}: {old_field} to "
+                "{new_name}: {new_field} in this migration. Primary keys and "
+                "backreferences will not be automatically migrated. If you want "
+                "to migrate primary keys, you should handle this in your "
+                "migrate() method."
+                    .format(old_name=old._primary_name,
+                            old_field=old._fields[old._primary_name],
+                            new_name=new._primary_name,
+                            new_field=new._fields[new._primary_name]))
 
         # Copy fields to new object
         for field in old._fields:
@@ -611,37 +609,30 @@ class StoredObject(object):
             if field not in cls._fields:
                 if rm_refs:
                     if verbose:
-                        print '''
-                            Backreferences to this object keyed on foreign field {name}: {field} will be deleted in this migration.
-                            To prevent this behavior, re-run with <rm_fwd_refs> set to False.
-                        '''.format(
-                            name=field,
-                            field=old._fields[field]
-                        )
+                        print("Backreferences to this object keyed on foreign "
+                            "field {name}: {field} will be deleted in this migration. "
+                            "To prevent this behavior, re-run with <rm_fwd_refs> "
+                            "set to False.".format(name=field,
+                                                  field=old._fields[field]))
                     if not dry_run:
                         rm_fwd_refs(old)
                 elif verbose:
-                    print '''
-                        Backreferences to this object keyed on foreign field {name}: {field} will be not deleted in this migration.
-                        To add this behavior, re-run with <rm_fwd_refs> set to True.
-                    '''.format(
-                        name=field,
-                        field=old._fields[field]
-                    )
+                    print("Backreferences to this object keyed on foreign field "
+                        "{name}: {field} will be not deleted in this migration. "
+                        "To add this behavior, re-run with <rm_fwd_refs> "
+                        "set to True.".format(name=field,
+                                            field=old._fields[field]))
                 continue
 
             # Check for field change
             if old._fields[field] != new._fields[field]:
                 if verbose:
-                    print '''
-                        Old field {name}: {old_field} differs from new field {name}: {new_field}.
-                        This field will not be automatically migrated. If you want to migrate this field,
-                        you should handle this in your migrate() method.
-                    '''.format(
-                        name=field,
-                        old_field=old._fields[field],
-                        new_field=new._fields[field],
-                    )
+                    print("Old field {name}: {old_field} differs from new field "
+                        "{name}: {new_field}. This field will not be automatically "
+                        "migrated. If you want to migrate this field, "
+                        "you should handle this in your migrate() method. "
+                            .format(name=field, old_field=old._fields[field],
+                                    new_field=new._fields[field]))
                 continue
 
             # Copy values of retained fields
@@ -680,13 +671,13 @@ class StoredObject(object):
             fr = classes[step]
             to = classes[step + 1]
 
-            print 'From schema {}'.format(fr._name)
-            print '\n'.join('\t{}'.format(field) for field in fr._fields)
-            print
+            print('From schema {0}'.format(fr._name))
+            print('\n'.join('\t{0}'.format(field) for field in fr._fields))
+            print()
 
-            print 'To schema {}'.format(to._name)
-            print '\n'.join('\t{}'.format(field) for field in to._fields)
-            print
+            print('To schema {0}'.format(to._name))
+            print('\n'.join('\t{0}'.format(field) for field in to._fields))
+            print()
 
             to.migrate(fr, to, verbose=True, dry_run=True)
 


### PR DESCRIPTION
Uses print function so output shows up as expected, without extraneous spacing (fixes #55).
