### PR TITLE
get $not working on mongo via $nor

### DIFF
--- a/modularodm/storage/mongostorage.py
+++ b/modularodm/storage/mongostorage.py
@@ -224,7 +224,9 @@ class MongoStorage(Storage):
                 return {'$or' : [self._translate_query(node) for node in query.nodes]}
 
             elif query.operator == 'not':
-                return {'$not' : self._translate_query(query.nodes[0])}
+                # boolean jiggery-pokery: A nor A == not A
+                subquery = self._translate_query(query.nodes[0])
+                return {'$nor' : [subquery, subquery]}
 
             else:
                 raise ValueError('QueryGroup operator must be <and>, <or>, or <not>.')

--- a/tests/queries/test_logical_operators.py
+++ b/tests/queries/test_logical_operators.py
@@ -46,13 +46,6 @@ class LogicalOperatorsBase(ModularOdmTestCase):
 
     def test_not(self):
         """ Finds the inverse of a query."""
-
-        # This is failing in Mongo, but works in Pickle. Mongo is getting:
-        #       {'$not': {'a': 0}}
-        # but it should be getting
-        #       {'a': {'$not': 0}}
-        #
-        # See: http://docs.mongodb.org/manual/reference/operator/not/
         result = self.Foo.find(~Q('a', 'eq', 0))
         self.assertEqual(
             len(result),


### PR DESCRIPTION
- modular-odm's "not" wasn't working on MongoDB, because their $not op
  cannot modify an equivalence like {a: "foo"}, and no $eq op is
  available.  Thankfully, they provide $nor and boolean logic dictates
  that (A $nor A) == ($not A).
- remove comment documenting this failure from test_logical_operators
