### PR TITLE
Skip object serialization in equality checks if possible.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 nose
+mock
 tox
 wheel
 invoke

--- a/modularodm/storedobject.py
+++ b/modularodm/storedobject.py
@@ -252,19 +252,16 @@ class StoredObject(object):
         try:
             if self is other:
                 return True
+            if self._primary_key != other._primary_key:
+                return False
             return self.to_storage() == other.to_storage()
         except (AttributeError, TypeError):
             # Can't compare with "other". Try the reverse comparison
             return NotImplemented
 
     def __ne__(self, other):
-        try:
-            if self is other:
-                return False
-            return self.to_storage() != other.to_storage()
-        except (AttributeError, TypeError):
-            # Can't compare with "other". Try the reverse comparison
-            return NotImplemented
+        equal = self.__eq__(other)
+        return equal if equal is NotImplemented else not equal
 
     @warn_if_detached
     def __unicode__(self):

--- a/tests/test_storedobject.py
+++ b/tests/test_storedobject.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import unittest
 import datetime
 import os
@@ -99,6 +100,26 @@ class TestStoredObject(unittest.TestCase):
         tag = Tag()
         tag.save()
         self._times_approx_equal(tag.date_modified)
+
+    @mock.patch('modularodm.storedobject.StoredObject.to_storage')
+    def test_eq_same_object_does_not_call_serialize(self, mock_serialize):
+        tag = Tag()
+        assert_true(tag == tag)
+        assert_false(tag != tag)
+        assert_false(mock_serialize.called)
+
+    @mock.patch('modularodm.storedobject.StoredObject.to_storage')
+    def test_eq_different_object_different_keys_does_not_call_serialize(self, mock_serialize):
+        tag1, tag2 = Tag(_id='foo'), Tag(_id='bar')
+        assert_false(tag1 == tag2)
+        assert_true(tag1 != tag2)
+        assert_false(mock_serialize.called)
+
+    @mock.patch('modularodm.storedobject.StoredObject.to_storage')
+    def test_eq_different_object_same_keys_calls_serialize(self, mock_serialize):
+        tag1, tag2 = Tag(_id='foo'), Tag(_id='foo')
+        tag1 == tag2
+        assert_true(mock_serialize.called)
 
     # Foreign tests
     def test_foreign_many_to_one_set(self):


### PR DESCRIPTION
Remove unnecessary serialization from **eq**, **ne**.
Test that serialization only happens in equality checks when necessary.
Add mock to dev-requirements.
