### PR TITLE
Support extended slicing in foreign lists.

### DIFF
--- a/modularodm/fields/lists.py
+++ b/modularodm/fields/lists.py
@@ -64,6 +64,8 @@ class ForeignList(BaseForeignList):
 
     def __getitem__(self, item):
         result = super(ForeignList, self).__getitem__(item)
+        if isinstance(item, slice):
+            return ForeignList(result, base_class=self._base_class)
         return self._base_class.load(result)
 
     def __getslice__(self, i, j):
@@ -127,6 +129,8 @@ class AbstractForeignList(BaseForeignList):
 
     def __getitem__(self, item):
         result = super(AbstractForeignList, self).__getitem__(item)
+        if isinstance(item, slice):
+            return AbstractForeignList(result)
         return self.get_foreign_object(result)
 
     def __getslice__(self, i, j):

--- a/tests/test_foreign.py
+++ b/tests/test_foreign.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+
+from nose.tools import *
+
+from tests.base import ModularOdmTestCase, TestObject
+
+from modularodm import fields
+
+
+class TestForeignList(ModularOdmTestCase):
+
+    def define_objects(self):
+
+        class Foo(TestObject):
+            _id = fields.IntegerField()
+            bars = fields.ForeignField('bar', list=True)
+
+        class Bar(TestObject):
+            _id = fields.IntegerField()
+
+        return Foo, Bar
+
+    def set_up_objects(self):
+
+        self.foo = self.Foo(_id=1)
+
+        self.bars = []
+        for idx in range(5):
+            self.bars.append(self.Bar(_id=idx))
+            self.bars[idx].save()
+
+        self.foo.bars = self.bars
+        self.foo.save()
+
+    def test_get_item(self):
+        assert_equal(self.bars[2], self.foo.bars[2])
+
+    def test_get_slice(self):
+        assert_equal(self.bars[:3], list(self.foo.bars[:3]))
+
+    def test_get_slice_extended(self):
+        assert_equal(self.bars[::-1], list(self.foo.bars[::-1]))
+
+
+class TestAbstractForeignList(ModularOdmTestCase):
+
+    def define_objects(self):
+
+        class Foo(TestObject):
+            _id = fields.IntegerField()
+            bars = fields.AbstractForeignField(list=True)
+
+        class Bar(TestObject):
+            _id = fields.IntegerField()
+
+        return Foo, Bar
+
+    def set_up_objects(self):
+
+        self.foo = self.Foo(_id=1)
+
+        self.bars = []
+        for idx in range(5):
+            self.bars.append(self.Bar(_id=idx))
+            self.bars[idx].save()
+
+        self.foo.bars = self.bars
+        self.foo.save()
+
+    def test_get_item(self):
+        assert_equal(self.bars[2], self.foo.bars[2])
+
+    def test_get_slice(self):
+        assert_equal(self.bars[:3], list(self.foo.bars[:3]))
+
+    def test_get_slice_extended(self):
+        assert_equal(self.bars[::-1], list(self.foo.bars[::-1]))
+

--- a/tests/test_storedobject.py
+++ b/tests/test_storedobject.py
@@ -250,21 +250,6 @@ class TestStoredObject(unittest.TestCase):
         assert_not_equal(user, different)
         assert_not_equal(None, user)
 
-    # def test_find_match(self):
-    #     tag = Tag()
-    #     tag.value = 'test_query_match'
-    #     tag.save()
-    #     results = Tag.find(Q('value', valu='test_query_match'))
-    #     results = list(results)
-    #     self.assertEqual(len(results), 1)
-    #
-    # def test_find_match_no_result(self):
-    #     tag = Tag()
-    #     tag.value = 'test_query_match'
-    #     tag.save()
-    #     results = Tag.find(Q('value', valu='no_matches_should_be_found!'))
-    #     results = list(results)
-    #     self.assertEqual(len(results), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
List indexing with a single integer (`data[1]`) and with an extended slice (`data[::-1]`) are both routed through `list#__getitem__`, so subclasses of `list` that override `__getitem__` must check the type of their input and return a single item or a list, as appropriate.
