### PR TITLE
multiple fields can now be updated at once

### DIFF
--- a/modularodm/storedobject.py
+++ b/modularodm/storedobject.py
@@ -843,6 +843,11 @@ class StoredObject(object):
 
         return fields_changed
 
+    def update_fields(self, **kwargs):
+        for key, value in kwargs.items():
+            self._fields[key].__set__(self, value, safe=True)
+
+
     def reload(self):
 
         storage_data = self._storage[0].get(self._primary_name, self._storage_key)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -34,6 +34,12 @@ class TestField(unittest.TestCase):
     def tearDown(self):
         pickle_storage._delete_file()
 
+    def test_update_fields(self):
+        u = User(name='foo')
+        u.update_fields(name="bazzle", _id=932)
+        assert_equal(u.name, "bazzle")
+        assert_equal(u._id, 932)
+
     def test_validators_must_be_callable(self):
         assert_raises(TypeError, lambda: fields.Field(validate="invalid"))
         assert_raises(TypeError, lambda: fields.Field(validate=["invalid"]))


### PR DESCRIPTION
#82 multiple fields can now be updated at once using the `update_fields` method on `storedobject`.