### PR TITLE
override remove method on instance to behave as expected

### DIFF
--- a/modularodm/storedobject.py
+++ b/modularodm/storedobject.py
@@ -219,7 +219,7 @@ class StoredObject(object):
     queue = WriteQueue()
 
     def __init__(self, **kwargs):
-
+        self.remove = lambda: self.remove_one(self)
         # Crash if abstract
         if self._is_abstract:
             raise TypeError('Cannot instantiate abstract schema')

--- a/tests/queries/test_update_queries.py
+++ b/tests/queries/test_update_queries.py
@@ -68,6 +68,15 @@ class UpdateQueryTestCase(ModularOdmTestCase):
             4
         )
 
+    def test_remove_on_instance(self):
+        """ calling remove on an instance removes the instance """
+        f = self.Foo.find()[0]
+        f.remove()
+        self.assertEqual(
+            self.Foo.find().count(),
+            4
+        )
+
     def test_remove_one(self):
         """ Given a primary key, remove the referenced object. """
         self.Foo.remove_one(Q('_id', 'eq', 2))


### PR DESCRIPTION
#97 I have to say this was a fun one with a annoyingly simple solution.
Now calling `remove` on an instance has the expected behavior and simply deletes that instance.
Calling `remove` on the class will still behave the same way.

I would also suggest removing the `query=None` from storedobject's `remove` method as it behaves different without a query based on which database you are using. i.e. the behavior referenced in #97 is only present in one of the test cases (mongo).


running this test:
```python
def test_remove_without_query(self):
        self.Foo.remove()
        self.assertEqual(
            self.Foo.find().count(),
            4
        )
```
will fail with: 
```
======================================================================
FAIL: test_remove_without_query (tests.queries.test_update_queries.UpdateQueryTestCaseEphemeral)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/adam/code/modular-odm/tests/queries/test_update_queries.py", line 75, in test_remove_without_query
    4
AssertionError: 5 != 4

======================================================================
FAIL: test_remove_without_query (tests.queries.test_update_queries.UpdateQueryTestCaseMongo)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/adam/code/modular-odm/tests/queries/test_update_queries.py", line 75, in test_remove_without_query
    4
AssertionError: 0 != 4

======================================================================
FAIL: test_remove_without_query (tests.queries.test_update_queries.UpdateQueryTestCasePickle)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/adam/code/modular-odm/tests/queries/test_update_queries.py", line 75, in test_remove_without_query
    4
AssertionError: 5 != 4

----------------------------------------------------------------------
Ran 580 tests in 2.535s

FAILED (SKIP=18, failures=3)
```