### PR TITLE
Remove custom __repr__ methods from Storage subclasses

### DIFF
--- a/modularodm/storage/mongostorage.py
+++ b/modularodm/storage/mongostorage.py
@@ -238,7 +238,3 @@ class MongoStorage(Storage):
 
     def flush(self):
         pass
-
-    def __repr__(self):
-        return self.find()
-

--- a/modularodm/storage/picklestorage.py
+++ b/modularodm/storage/picklestorage.py
@@ -257,6 +257,3 @@ class PickleStorage(Storage):
                         yield key
                     else:
                         yield value
-
-    def __repr__(self):
-        return str(self.store)


### PR DESCRIPTION
Closes #112

`PickleStorage.__repr__` was removed as well, not because it was causing problems but to maintain consistent behavior in `Storage` subclasses.