### PR TITLE
Move `KeyExistsException`

### DIFF
--- a/modularodm/exceptions.py
+++ b/modularodm/exceptions.py
@@ -9,6 +9,12 @@ class QueryException(ModularOdmException):
     pass
 
 
+class KeyExistsException(QueryException):
+    """Raised when a insert in an object with a primary key that already exists.
+    """
+    pass
+
+
 class MultipleResultsFound(QueryException):
     """ Raised when multiple results match the passed query, and only a single
     object may be returned """

--- a/modularodm/storage/base.py
+++ b/modularodm/storage/base.py
@@ -6,10 +6,7 @@ import itertools
 from functools import wraps
 
 from ..translators import DefaultTranslator
-
-
-class KeyExistsException(Exception):
-    pass
+from modularodm.exceptions import KeyExistsException
 
 
 class Logger(object):

--- a/modularodm/storage/mongostorage.py
+++ b/modularodm/storage/mongostorage.py
@@ -3,11 +3,15 @@
 import re
 import pymongo
 
-from .base import Storage, KeyExistsException
+from .base import Storage
 from ..query.queryset import BaseQuerySet
 from ..query.query import QueryGroup
 from ..query.query import RawQuery
-from modularodm.exceptions import NoResultsFound, MultipleResultsFound
+from modularodm.exceptions import (
+    KeyExistsException,
+    MultipleResultsFound,
+    NoResultsFound,
+)
 
 
 # From mongoengine.queryset.transform

--- a/modularodm/storage/picklestorage.py
+++ b/modularodm/storage/picklestorage.py
@@ -5,13 +5,17 @@ import copy
 
 import six
 
-from .base import Storage, KeyExistsException
+from .base import Storage
 from ..query.queryset import BaseQuerySet
 from ..query.query import QueryGroup
 from ..query.query import RawQuery
 
 from modularodm.utils import DirtyField
-from modularodm.exceptions import MultipleResultsFound, NoResultsFound
+from modularodm.exceptions import (
+    KeyExistsException,
+    MultipleResultsFound,
+    NoResultsFound,
+)
 
 try:
     import cpickle as pickle


### PR DESCRIPTION
Exception was previously defined in modularodm.storage.base, and was not
a subclass of ModularOdmException. The definition was moved, and the
exception was changed to reflect the correct parent class. As it is
imported into the context where it was previously defined, existing code
that imports it from there will continue to work. New code should import
it from `modularodm.exceptions`.