### PR TITLE
Raise a ValueError when the stored value is not an AbstractForeignField

### DIFF
--- a/modularodm/fields/abstractforeignfield.py
+++ b/modularodm/fields/abstractforeignfield.py
@@ -43,6 +43,8 @@ class AbstractForeignField(BaseForeignField):
 
         if value is None:
             return None
+        if not isinstance(value, (tuple, list)) or len(value) != 2:
+            raise ValueError('Value must be a list or tuple with a length of 2')
         return (
             self.get_primary_field(value[1])\
                 .from_storage(value[0], translator),


### PR DESCRIPTION
  Stored values of AbstractForeignFields must be either a tuple or a
  list of length 2, (object_id, modelname). When strings are found in
  this field a very cryptic error would get raised.
