### PR TITLE
Updated url validator regex [#OSF-4842]

### DIFF
--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -84,14 +84,14 @@ class RegexValidator(Validator):
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
     regex = re.compile(
-        r'^(?:(?:https?|ftp)://)?'  # http:// or https://
-        r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+        ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
+        ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
         ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'  # domain...
-        r'localhost|'  # localhost...
-        r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' #...or ipv4
-        r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # ...or ipv6
-        r'(?::\d{2,5})?'  # optional port
-        r'(?:/|/\S+)*$', re.IGNORECASE)
+        ur'localhost|'  # localhost...
+        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' #...or ipv4
+        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # ...or ipv6
+        ur'(?::\d{2,5})?'  # optional port
+        ur'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
 
     def __call__(self, value):

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import six
-from six.moves.urllib_parse import urlsplit, urlunsplit
 
 from modularodm.exceptions import (
     ValidationError,
@@ -85,14 +84,14 @@ class RegexValidator(Validator):
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
     regex = re.compile(
-        r'^(?:(?:https?|ftp)://)?'  # http:// or https://
-        r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        u'(?:(?:(?:[\\u00a1-\\uffffA-Z0-9][\\u00a1-\\uffffA-Z0-9-]{0,61}[\\u00a1-\\uffffA-Z0-9]?\.)+(?:[\\u00a1-\\uffffA-Z0-9]{2,}))|' # domain
-        r'localhost|'  # localhost
-        r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
-        r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
-        r'(?::\d{2,5})?'  # optional port
-        r'(?:/|/\S+)*$', re.IGNORECASE)
+        ur'^(?:(?:https?|ftp)://)?'+  # http:// or https://
+        ur'(?:\S+(?::\S*)?@)?'+  # user:passauthentication
+        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'+ # domain
+        ur'localhost|'+  # localhost
+        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'+ # or ipv4
+        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'+  # or ipv6
+        ur'(?::\d{2,5})?'+  # optional port
+        ur'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
 
     def __call__(self, value):

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -83,18 +83,28 @@ class RegexValidator(Validator):
 
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
-    expression = ur'^(?:(?:https?|ftp)://)?(?:\S+(?::\S*)?@)?(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|localhost|(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))(\?[;&a-z\d%_.~+=-]*)?(?::\d{2,5})?(?:/|/\S+)*$'
-    regex = re.compile(expression, re.IGNORECASE)
-        #ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
-        #ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        #ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
-        #ur'localhost|'  # localhost
-        #ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
-        #ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
-        #ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
-        #ur'(?::\d{2,5})?'  # optional port
-        #ur'(?:/|/\S+)*$', re.IGNORECASE)
-
+    if six.PY2:
+        regex = re.compile(
+            ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
+            ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+            ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+            ur'localhost|'  # localhost
+            ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
+            ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+            ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
+            ur'(?::\d{2,5})?'  # optional port
+            ur'(?:/|/\S+)*$', re.IGNORECASE)
+    else:
+        regex = re.compile(
+            r'^(?:(?:https?|ftp)://)?'  # http:// or https://
+            r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+            r'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'  # domain
+            r'localhost|'  # localhost
+            r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'  # or ipv4
+            r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+            r'(\?[;&a-z\d%_.~+=-]*)?'  # query string
+            r'(?::\d{2,5})?'  # optional port
+            r'(?:/|/\S+)*$', re.IGNORECASE)
 
     # message = _('Enter a valid URL.')
 

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -87,10 +87,10 @@ class URLValidator(RegexValidator):
     regex = re.compile(
         r'^(?:(?:https?|ftp)://)?'  # http:// or https://
         r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'  # domain...
-        r'localhost|'  # localhost...
-        r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' #...or ipv4
-        r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # ...or ipv6
+        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        r'localhost|'  # localhost
+        r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
+        r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
         r'(?::\d{2,5})?'  # optional port
         r'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -84,13 +84,13 @@ class RegexValidator(Validator):
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
     regex = re.compile(
-        ur'^(?:(?:https?|ftp)://)?'+  # http:// or https://
-        ur'(?:\S+(?::\S*)?@)?'+  # user:passauthentication
-        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'+ # domain
-        ur'localhost|'+  # localhost
-        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'+ # or ipv4
-        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'+  # or ipv6
-        ur'(?::\d{2,5})?'+  # optional port
+        ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
+        ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        ur'localhost|'  # localhost
+        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
+        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+        ur'(?::\d{2,5})?'  # optional port
         ur'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
 

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -86,7 +86,7 @@ class URLValidator(RegexValidator):
     regex = re.compile(
         u'^(?:(?:https?|ftp)://)?'  # http:// or https://
         u'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        u'(?:(?:(?:[\\u00a1-\uffffA-Z0-9][\\u00a1-\uffffA-Z0-9-]{0,61}[\\u00a1-\uffffA-Z0-9]?\.)+(?:[\\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        u'(?:(?:(?:[\\u00a1-\uffffA-Z0-9][\\u00a1-\uffffA-Z0-9-]{0,61}[\\u00a1-\uffffA-Z0-9]?\.){1,2}(?:[\\u00a1-\uffffA-Z0-9]{2,}))|' # domain
         u'localhost|'  # localhost
         u'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'  # or ipv4
         u'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -74,7 +74,7 @@ class RegexValidator(Validator):
 
         if not self.regex.findall(value):
             raise ValidationError(
-                'Value must match regex {0} and flags {1}; received value <{2}>'.format(
+                u'Value must match regex {0} and flags {1}; received value <{2}>'.format(
                     self.regex.pattern,
                     self.regex.flags,
                     value
@@ -90,6 +90,7 @@ class URLValidator(RegexValidator):
         ur'localhost|'  # localhost
         ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
         ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+        ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
         ur'(?::\d{2,5})?'  # optional port
         ur'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
@@ -97,7 +98,7 @@ class URLValidator(RegexValidator):
     def __call__(self, value):
         try:
             super(URLValidator, self).__call__(value)
-        except ValidationError as e:
+        except ValidationError:
                 raise
         else:
             pass

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -83,16 +83,19 @@ class RegexValidator(Validator):
 
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
-    regex = re.compile(
-        ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
-        ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
-        ur'localhost|'  # localhost
-        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
-        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
-        ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
-        ur'(?::\d{2,5})?'  # optional port
-        ur'(?:/|/\S+)*$', re.IGNORECASE)
+    expression = ur'^(?:(?:https?|ftp)://)?(?:\S+(?::\S*)?@)?(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|localhost|(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))(\?[;&a-z\d%_.~+=-]*)?(?::\d{2,5})?(?:/|/\S+)*$'
+    regex = re.compile(expression, re.IGNORECASE)
+        #ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
+        #ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+        #ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        #ur'localhost|'  # localhost
+        #ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
+        #ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+        #ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
+        #ur'(?::\d{2,5})?'  # optional port
+        #ur'(?:/|/\S+)*$', re.IGNORECASE)
+
+
     # message = _('Enter a valid URL.')
 
     def __call__(self, value):

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -87,7 +87,7 @@ class URLValidator(RegexValidator):
     regex = re.compile(
         r'^(?:(?:https?|ftp)://)?'  # http:// or https://
         r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-        ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        u'(?:(?:(?:[\\u00a1-\\uffffA-Z0-9][\\u00a1-\\uffffA-Z0-9-]{0,61}[\\u00a1-\\uffffA-Z0-9]?\.)+(?:[\\u00a1-\\uffffA-Z0-9]{2,}))|' # domain
         r'localhost|'  # localhost
         r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
         r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
@@ -99,7 +99,7 @@ class URLValidator(RegexValidator):
         try:
             super(URLValidator, self).__call__(value)
         except ValidationError as e:
-                raise e
+                raise
         else:
             pass
 

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -83,39 +83,26 @@ class RegexValidator(Validator):
 
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
-    if six.PY2:
-        regex = re.compile(
-            ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
-            ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-            ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|' # domain
-            ur'localhost|'  # localhost
-            ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' # or ipv4
-            ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
-            ur'(\?[;&a-z\d%_.~+=-]*)?' # query string
-            ur'(?::\d{2,5})?'  # optional port
-            ur'(?:/|/\S+)*$', re.IGNORECASE)
-    else:
-        regex = re.compile(
-            r'^(?:(?:https?|ftp)://)?'  # http:// or https://
-            r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
-            r'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'  # domain
-            r'localhost|'  # localhost
-            r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'  # or ipv4
-            r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
-            r'(\?[;&a-z\d%_.~+=-]*)?'  # query string
-            r'(?::\d{2,5})?'  # optional port
-            r'(?:/|/\S+)*$', re.IGNORECASE)
-
+    regex = re.compile(
+        u'^(?:(?:https?|ftp)://)?'  # http:// or https://
+        u'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+        u'(?:(?:(?:[\\u00a1-\uffffA-Z0-9][\\u00a1-\uffffA-Z0-9-]{0,61}[\\u00a1-\uffffA-Z0-9]?\.)+(?:[\\u00a1-\uffffA-Z0-9]{2,}))|' # domain
+        u'localhost|'  # localhost
+        u'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|'  # or ipv4
+        u'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # or ipv6
+        u'(\?[;&a-z\d%_.~+=-]*)?'  # query string
+        u'(?::\d{2,5})?'  # optional port
+        u'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
 
     def __call__(self, value):
+
         try:
             super(URLValidator, self).__call__(value)
         except ValidationError:
                 raise
         else:
             pass
-
 
 class BaseValidator(Validator):
 

--- a/modularodm/validators/__init__.py
+++ b/modularodm/validators/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import six
 from six.moves.urllib_parse import urlsplit, urlunsplit
 
@@ -84,14 +85,14 @@ class RegexValidator(Validator):
 # Adapted from Django URLValidator
 class URLValidator(RegexValidator):
     regex = re.compile(
-        ur'^(?:(?:https?|ftp)://)?'  # http:// or https://
-        ur'(?:\S+(?::\S*)?@)?'  # user:passauthentication
+        r'^(?:(?:https?|ftp)://)?'  # http:// or https://
+        r'(?:\S+(?::\S*)?@)?'  # user:passauthentication
         ur'(?:(?:(?:[\u00a1-\uffffA-Z0-9][\u00a1-\uffffA-Z0-9-]{0,61}[\u00a1-\uffffA-Z0-9]?\.)+(?:[\u00a1-\uffffA-Z0-9]{2,}))|'  # domain...
-        ur'localhost|'  # localhost...
-        ur'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' #...or ipv4
-        ur'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # ...or ipv6
-        ur'(?::\d{2,5})?'  # optional port
-        ur'(?:/|/\S+)*$', re.IGNORECASE)
+        r'localhost|'  # localhost...
+        r'(?:(?:(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[1]?[0-9]?[0-9]))|' #...or ipv4
+        r'(?:\[?[A-F0-9]*:[A-F0-9:]+\]?))'  # ...or ipv6
+        r'(?::\d{2,5})?'  # optional port
+        r'(?:/|/\S+)*$', re.IGNORECASE)
     # message = _('Enter a valid URL.')
 
     def __call__(self, value):

--- a/tests/validators/test_url_validation.py
+++ b/tests/validators/test_url_validation.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from modularodm import StoredObject
+from modularodm.exceptions import ValidationError
+from modularodm.fields import StringField, IntegerField
+from modularodm.validators import URLValidator
+
+from tests.base import ModularOdmTestCase
+
+class UrlValueValidatorTestCase(ModularOdmTestCase):
+
+    def test_url(self):
+
+        testsPositive = [u'http://Bücher.de', u'http://localhost:5000/meetings', u'http://foo.com/blah_blah',
+                         u'http://foo.com/blah_blah/', u'http://foo.com/blah_blah_(wikipedia)',
+                         u'http://userid:password@example.com:8080', u'http://userid:password@example.com:8080/',
+                         u'http://userid@example.com', u'http://userid@example.com/', u'http://userid@example.com:8080',
+                         u'http://userid@example.com:8080/', u'http://userid:password@example.com',
+                         u'http://userid:password@example.com/', u'http://142.42.1.1', u'http://142.42.1.1/',
+                         u'http://142.42.1.1:8080/',
+                         u'http://➡.ws/䨹', u'http://⌘.ws', u'http://⌘.ws/', u'http://foo.com/blah_(wikipedia)#cite-1',
+                         u'http://foo.com/blah_(wikipedia)_blah#cite-1', u'http://foo.com/unicode_(✪)_in_parens',
+                         u'http://foo.com/(something)?after=parens', u'http://☺.damowmow.com/',
+                         u'http://code.google.com/events/#&product=browser', u'http://j.mp', u'ftp://foo.bar/baz',
+                         u'http://foo.bar/?q=Test%20URL-encoded%20stuff', u'http://مثال.إختبار', u'http://例子.测试',
+                         u'http://उदाहरण.परीक्षा', u'http://-.~_!$&\'()*+,;=:%40:80%2f::::::@example.com',
+                         u'http://1337.net', u'definitelyawebsite.com?real=yes&page=definitely',
+                         u'http://a.b-c.de',
+                         u'http://10.1.1.0', u'http://10.1.1.255', u'http://224.1.1.1', u'foo.com', ]
+
+        testsNegative = [u'http://', u'http://.', u'http://..', u'http://../',
+                         u'http://?', u'http://??', u'http://??/', u'http://#', u'http://##', u'http://##/',
+                         u'http://foo.bar?q=Spaces should be encoded', u'//', u'//a', u'///a', u'///', u'http:///a',
+                         u'rdar://1234', u'h://test', u'http:// shouldfail.com', u':// should fail',
+                         u'http://foo.bar/foo(bar)baz quux', u'ftps://foo.bar/', u'http://-error-.invalid/',
+                         u'http://1.1.1.1.1', u'http://-a.b.co',
+                         u'http://3628126748', u'http://.www.foo.bar/', u'http://www.foo.bar./',
+                         u'http://.www.foo.bar./']
+
+        class Foo(StoredObject):
+            _id = IntegerField()
+            url_field = StringField(
+                list=False,
+                validate=[URLValidator()]
+            )
+
+        Foo.set_storage(self.make_storage())
+        test_object = Foo()
+
+        for urlTrue in testsPositive:
+            test_object.url_field = urlTrue
+            test_object.save()
+
+        for urlFalse in testsNegative:
+            test_object.url_field = urlFalse
+            with self.assertRaises(ValidationError):
+                test_object.save()


### PR DESCRIPTION
Did a general overhaul on url validator regex. Now allows unicode in domain. 
This change is relevant on both
https://openscience.atlassian.net/browse/OSF-4842
and
https://openscience.atlassian.net/browse/OSF-6831